### PR TITLE
Add transparent border to tablet view menu buttons

### DIFF
--- a/assets/styles/project.css
+++ b/assets/styles/project.css
@@ -286,6 +286,7 @@ display: none;
   display: inline-block;
   width: 33%;
   text-align: center;
+  border: 2px transparent solid;
 }
 
 .tabletMenu a:hover{

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -204,6 +204,7 @@
     display: inline-block;
     width: 33%;
     text-align: center;
+    border: solid transparent 2px;
   }
 
   .tabletMenu a:hover{


### PR DESCRIPTION
Gets rid of content shifting below the buttons. 